### PR TITLE
BM-57: Fix migrations

### DIFF
--- a/migrations/Version20220418144600.php
+++ b/migrations/Version20220418144600.php
@@ -19,41 +19,40 @@ final class Version20220418144600 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE brand (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(150) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE color (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE country (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(100) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE image (id INT AUTO_INCREMENT NOT NULL, product_id INT NOT NULL, src VARCHAR(255) NOT NULL, INDEX IDX_C53D045F4584665A (product_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE memory (id INT AUTO_INCREMENT NOT NULL, memory_capacity VARCHAR(80) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE product (id INT AUTO_INCREMENT NOT NULL, country_id INT DEFAULT NULL, memory_id INT DEFAULT NULL, brand_id INT DEFAULT NULL, user_id INT NOT NULL, name VARCHAR(100) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME NOT NULL, INDEX IDX_D34A04ADF92F3E70 (country_id), INDEX IDX_D34A04ADCCC80CB3 (memory_id), INDEX IDX_D34A04AD44F5D008 (brand_id), INDEX IDX_D34A04ADA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE product_color (fk_product INT NOT NULL, fk_color INT NOT NULL, INDEX IDX_C70A33B523653981 (fk_product), INDEX IDX_C70A33B5A7BB6B9C (fk_color), PRIMARY KEY(fk_product, fk_color)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE user (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE image ADD CONSTRAINT FK_C53D045F4584665A FOREIGN KEY (product_id) REFERENCES product (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADF92F3E70 FOREIGN KEY (country_id) REFERENCES country (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADCCC80CB3 FOREIGN KEY (memory_id) REFERENCES memory (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04AD44F5D008 FOREIGN KEY (brand_id) REFERENCES brand (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADA76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
-        $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B523653981 FOREIGN KEY (fk_product) REFERENCES product (id)');
-        $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B5A7BB6B9C FOREIGN KEY (fk_color) REFERENCES color (id)');
+	    // this up() migration is auto-generated, please modify it to your needs
+	    $this->addSql('CREATE TABLE IF NOT EXISTS brand (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(150) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS color (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS country (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(100) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS image (id INT AUTO_INCREMENT NOT NULL, product_id INT NOT NULL, src VARCHAR(255) NOT NULL, INDEX IDX_C53D045F4584665A (product_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS memory (id INT AUTO_INCREMENT NOT NULL, memory_capacity VARCHAR(80) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS product (id INT AUTO_INCREMENT NOT NULL, country_id INT DEFAULT NULL, memory_id INT DEFAULT NULL, brand_id INT DEFAULT NULL, user_id INT NOT NULL, name VARCHAR(100) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME NOT NULL, INDEX IDX_D34A04ADF92F3E70 (country_id), INDEX IDX_D34A04ADCCC80CB3 (memory_id), INDEX IDX_D34A04AD44F5D008 (brand_id), INDEX IDX_D34A04ADA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS product_color (fk_product INT NOT NULL, fk_color INT NOT NULL, INDEX IDX_C70A33B523653981 (fk_product), INDEX IDX_C70A33B5A7BB6B9C (fk_color), PRIMARY KEY(fk_product, fk_color)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS user (id INT AUTO_INCREMENT NOT NULL, email VARCHAR(180) NOT NULL, roles JSON NOT NULL, password VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('ALTER TABLE image ADD CONSTRAINT FK_C53D045F4584665A FOREIGN KEY (product_id) REFERENCES product (id)');
+	    $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADF92F3E70 FOREIGN KEY (country_id) REFERENCES country (id)');
+	    $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADCCC80CB3 FOREIGN KEY (memory_id) REFERENCES memory (id)');
+	    $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04AD44F5D008 FOREIGN KEY (brand_id) REFERENCES brand (id)');
+	    $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADA76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+	    $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B523653981 FOREIGN KEY (fk_product) REFERENCES product (id)');
+	    $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B5A7BB6B9C FOREIGN KEY (fk_color) REFERENCES color (id)');
     }
 
-    public function down(Schema $schema): void
-    {
-        // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04AD44F5D008');
-        $this->addSql('ALTER TABLE product_color DROP FOREIGN KEY FK_C70A33B5A7BB6B9C');
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADF92F3E70');
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADCCC80CB3');
-        $this->addSql('ALTER TABLE image DROP FOREIGN KEY FK_C53D045F4584665A');
-        $this->addSql('ALTER TABLE product_color DROP FOREIGN KEY FK_C70A33B523653981');
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADA76ED395');
-        $this->addSql('DROP TABLE brand');
-        $this->addSql('DROP TABLE color');
-        $this->addSql('DROP TABLE country');
-        $this->addSql('DROP TABLE image');
-        $this->addSql('DROP TABLE memory');
-        $this->addSql('DROP TABLE product');
-        $this->addSql('DROP TABLE product_color');
-        $this->addSql('DROP TABLE user');
+    public function down(Schema $schema): void {
+	    // this down() migration is auto-generated, please modify it to your needs
+	    $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04AD44F5D008');
+	    $this->addSql('ALTER TABLE product_color DROP FOREIGN KEY FK_C70A33B5A7BB6B9C');
+	    $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADF92F3E70');
+	    $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADCCC80CB3');
+	    $this->addSql('ALTER TABLE image DROP FOREIGN KEY FK_C53D045F4584665A');
+	    $this->addSql('ALTER TABLE product_color DROP FOREIGN KEY FK_C70A33B523653981');
+	    $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADA76ED395');
+	    $this->addSql('DROP TABLE IF EXISTS brand');
+	    $this->addSql('DROP TABLE IF EXISTS color');
+	    $this->addSql('DROP TABLE IF EXISTS country');
+	    $this->addSql('DROP TABLE IF EXISTS image');
+	    $this->addSql('DROP TABLE IF EXISTS memory');
+	    $this->addSql('DROP TABLE IF EXISTS product');
+	    $this->addSql('DROP TABLE IF EXISTS product_color');
+	    $this->addSql('DROP TABLE IF EXISTS user');
     }
 }

--- a/migrations/Version20220418160021.php
+++ b/migrations/Version20220418160021.php
@@ -20,14 +20,14 @@ final class Version20220418160021 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('DROP TABLE product_color');
+        $this->addSql('DROP TABLE IF EXISTS product_color');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE product_color (fk_product INT NOT NULL, fk_color INT NOT NULL, INDEX IDX_C70A33B523653981 (fk_product), INDEX IDX_C70A33B5A7BB6B9C (fk_color), PRIMARY KEY(fk_product, fk_color)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
-        $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B523653981 FOREIGN KEY (fk_product) REFERENCES product (id) ON UPDATE NO ACTION ON DELETE CASCADE');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS product_color (fk_product INT NOT NULL, fk_color INT NOT NULL, INDEX IDX_C70A33B523653981 (fk_product), INDEX IDX_C70A33B5A7BB6B9C (fk_color), PRIMARY KEY(fk_product, fk_color)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
+	    $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B523653981 FOREIGN KEY (fk_product) REFERENCES product (id) ON UPDATE NO ACTION ON DELETE CASCADE');
         $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B5A7BB6B9C FOREIGN KEY (fk_color) REFERENCES color (id) ON UPDATE NO ACTION ON DELETE CASCADE');
     }
 }

--- a/migrations/Version20220418161029.php
+++ b/migrations/Version20220418161029.php
@@ -20,14 +20,14 @@ final class Version20220418161029 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE product_color (product_id INT NOT NULL, color_id INT NOT NULL, INDEX IDX_C70A33B54584665A (product_id), INDEX IDX_C70A33B57ADA1FB5 (color_id), PRIMARY KEY(product_id, color_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B54584665A FOREIGN KEY (product_id) REFERENCES product (id) ON DELETE CASCADE');
+        $this->addSql('CREATE TABLE IF NOT EXISTS product_color (product_id INT NOT NULL, color_id INT NOT NULL, INDEX IDX_C70A33B54584665A (product_id), INDEX IDX_C70A33B57ADA1FB5 (color_id), PRIMARY KEY(product_id, color_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B54584665A FOREIGN KEY (product_id) REFERENCES product (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B57ADA1FB5 FOREIGN KEY (color_id) REFERENCES color (id) ON DELETE CASCADE');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('DROP TABLE product_color');
+	    $this->addSql('DROP TABLE IF EXISTS product_color');
     }
 }

--- a/migrations/Version20220422142024.php
+++ b/migrations/Version20220422142024.php
@@ -20,12 +20,12 @@ final class Version20220422142024 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE customer (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(100) NOT NULL, status TINYINT(1) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE IF NOT EXISTS customer (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(100) NOT NULL, status TINYINT(1) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
     }
 
     public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('DROP TABLE customer');
+	    $this->addSql('DROP TABLE IF EXISTS customer');
     }
 }

--- a/migrations/Version20220506152332.php
+++ b/migrations/Version20220506152332.php
@@ -19,20 +19,19 @@ final class Version20220506152332 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE role (id INT AUTO_INCREMENT NOT NULL, role_name VARCHAR(30) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE user_role (user_id INT NOT NULL, role_id INT NOT NULL, INDEX IDX_2DE8C6A3A76ED395 (user_id), INDEX IDX_2DE8C6A3D60322AC (role_id), PRIMARY KEY(user_id, role_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE user_role ADD CONSTRAINT FK_2DE8C6A3A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE user_role ADD CONSTRAINT FK_2DE8C6A3D60322AC FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE user DROP roles');
+	    // this up() migration is auto-generated, please modify it to your needs
+	    $this->addSql('CREATE TABLE IF NOT EXISTS role (id INT AUTO_INCREMENT NOT NULL, role_name VARCHAR(30) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS user_role (user_id INT NOT NULL, role_id INT NOT NULL, INDEX IDX_2DE8C6A3A76ED395 (user_id), INDEX IDX_2DE8C6A3D60322AC (role_id), PRIMARY KEY(user_id, role_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('ALTER TABLE user_role ADD CONSTRAINT FK_2DE8C6A3A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+	    $this->addSql('ALTER TABLE user_role ADD CONSTRAINT FK_2DE8C6A3D60322AC FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE CASCADE');
+	    $this->addSql('ALTER TABLE user DROP roles');
     }
 
-    public function down(Schema $schema): void
-    {
-        // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE user_role DROP FOREIGN KEY FK_2DE8C6A3D60322AC');
-        $this->addSql('DROP TABLE role');
-        $this->addSql('DROP TABLE user_role');
-        $this->addSql('ALTER TABLE user ADD roles JSON NOT NULL');
+    public function down(Schema $schema): void {
+	    // this down() migration is auto-generated, please modify it to your needs
+	    $this->addSql('ALTER TABLE user_role DROP FOREIGN KEY FK_2DE8C6A3D60322AC');
+	    $this->addSql('DROP TABLE IF EXISTS role');
+	    $this->addSql('DROP TABLE IF EXISTS user_role');
+	    $this->addSql('ALTER TABLE user ADD roles JSON NOT NULL');
     }
 }

--- a/migrations/Version20220525080537.php
+++ b/migrations/Version20220525080537.php
@@ -19,53 +19,32 @@ final class Version20220525080537 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE brand (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_1C52F9585E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE color (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_665648E95E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE country (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_5373C9665E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE customer (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(30) NOT NULL, enabled TINYINT(1) NOT NULL, company VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_81398E094FBF094F (company), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE image (id INT AUTO_INCREMENT NOT NULL, product_id INT NOT NULL, src VARCHAR(255) NOT NULL, INDEX IDX_C53D045F4584665A (product_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE memory (id INT AUTO_INCREMENT NOT NULL, memory_capacity VARCHAR(10) NOT NULL, UNIQUE INDEX UNIQ_EA6D3435A3B739CF (memory_capacity), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE product (id INT AUTO_INCREMENT NOT NULL, country_id INT DEFAULT NULL, memory_id INT DEFAULT NULL, brand_id INT DEFAULT NULL, user_id INT NOT NULL, name VARCHAR(60) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME NOT NULL, UNIQUE INDEX UNIQ_D34A04AD5E237E06 (name), INDEX IDX_D34A04ADF92F3E70 (country_id), INDEX IDX_D34A04ADCCC80CB3 (memory_id), INDEX IDX_D34A04AD44F5D008 (brand_id), INDEX IDX_D34A04ADA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE product_color (product_id INT NOT NULL, color_id INT NOT NULL, INDEX IDX_C70A33B54584665A (product_id), INDEX IDX_C70A33B57ADA1FB5 (color_id), PRIMARY KEY(product_id, color_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE role (id INT AUTO_INCREMENT NOT NULL, role_name VARCHAR(30) NOT NULL, UNIQUE INDEX UNIQ_57698A6AE09C0C92 (role_name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE user (id INT AUTO_INCREMENT NOT NULL, customer_id INT DEFAULT NULL, email VARCHAR(50) NOT NULL, password VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), INDEX IDX_8D93D6499395C3F3 (customer_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('CREATE TABLE user_role (user_id INT NOT NULL, role_id INT NOT NULL, INDEX IDX_2DE8C6A3A76ED395 (user_id), INDEX IDX_2DE8C6A3D60322AC (role_id), PRIMARY KEY(user_id, role_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE image ADD CONSTRAINT FK_C53D045F4584665A FOREIGN KEY (product_id) REFERENCES product (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADF92F3E70 FOREIGN KEY (country_id) REFERENCES country (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADCCC80CB3 FOREIGN KEY (memory_id) REFERENCES memory (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04AD44F5D008 FOREIGN KEY (brand_id) REFERENCES brand (id)');
-        $this->addSql('ALTER TABLE product ADD CONSTRAINT FK_D34A04ADA76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
-        $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B54584665A FOREIGN KEY (product_id) REFERENCES product (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE product_color ADD CONSTRAINT FK_C70A33B57ADA1FB5 FOREIGN KEY (color_id) REFERENCES color (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE user ADD CONSTRAINT FK_8D93D6499395C3F3 FOREIGN KEY (customer_id) REFERENCES customer (id)');
-        $this->addSql('ALTER TABLE user_role ADD CONSTRAINT FK_2DE8C6A3A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE user_role ADD CONSTRAINT FK_2DE8C6A3D60322AC FOREIGN KEY (role_id) REFERENCES role (id) ON DELETE CASCADE');
+	    // this up() migration is auto-generated, please modify it to your needs
+	    $this->addSql('CREATE TABLE IF NOT EXISTS brand (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_1C52F9585E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS color (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_665648E95E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS country (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_5373C9665E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS customer (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(30) NOT NULL, enabled TINYINT(1) NOT NULL, company VARCHAR(60) NOT NULL, UNIQUE INDEX UNIQ_81398E094FBF094F (company), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS image (id INT AUTO_INCREMENT NOT NULL, product_id INT NOT NULL, src VARCHAR(255) NOT NULL, INDEX IDX_C53D045F4584665A (product_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS memory (id INT AUTO_INCREMENT NOT NULL, memory_capacity VARCHAR(10) NOT NULL, UNIQUE INDEX UNIQ_EA6D3435A3B739CF (memory_capacity), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS product (id INT AUTO_INCREMENT NOT NULL, country_id INT DEFAULT NULL, memory_id INT DEFAULT NULL, brand_id INT DEFAULT NULL, user_id INT NOT NULL, name VARCHAR(60) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME NOT NULL, UNIQUE INDEX UNIQ_D34A04AD5E237E06 (name), INDEX IDX_D34A04ADF92F3E70 (country_id), INDEX IDX_D34A04ADCCC80CB3 (memory_id), INDEX IDX_D34A04AD44F5D008 (brand_id), INDEX IDX_D34A04ADA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS product_color (product_id INT NOT NULL, color_id INT NOT NULL, INDEX IDX_C70A33B54584665A (product_id), INDEX IDX_C70A33B57ADA1FB5 (color_id), PRIMARY KEY(product_id, color_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS role (id INT AUTO_INCREMENT NOT NULL, role_name VARCHAR(30) NOT NULL, UNIQUE INDEX UNIQ_57698A6AE09C0C92 (role_name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS user (id INT AUTO_INCREMENT NOT NULL, customer_id INT DEFAULT NULL, email VARCHAR(50) NOT NULL, password VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_8D93D649E7927C74 (email), INDEX IDX_8D93D6499395C3F3 (customer_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+	    $this->addSql('CREATE TABLE IF NOT EXISTS user_role (user_id INT NOT NULL, role_id INT NOT NULL, INDEX IDX_2DE8C6A3A76ED395 (user_id), INDEX IDX_2DE8C6A3D60322AC (role_id), PRIMARY KEY(user_id, role_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
     }
 
-    public function down(Schema $schema): void
-    {
-        // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04AD44F5D008');
-        $this->addSql('ALTER TABLE product_color DROP FOREIGN KEY FK_C70A33B57ADA1FB5');
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADF92F3E70');
-        $this->addSql('ALTER TABLE user DROP FOREIGN KEY FK_8D93D6499395C3F3');
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADCCC80CB3');
-        $this->addSql('ALTER TABLE image DROP FOREIGN KEY FK_C53D045F4584665A');
-        $this->addSql('ALTER TABLE product_color DROP FOREIGN KEY FK_C70A33B54584665A');
-        $this->addSql('ALTER TABLE user_role DROP FOREIGN KEY FK_2DE8C6A3D60322AC');
-        $this->addSql('ALTER TABLE product DROP FOREIGN KEY FK_D34A04ADA76ED395');
-        $this->addSql('ALTER TABLE user_role DROP FOREIGN KEY FK_2DE8C6A3A76ED395');
-        $this->addSql('DROP TABLE brand');
-        $this->addSql('DROP TABLE color');
-        $this->addSql('DROP TABLE country');
-        $this->addSql('DROP TABLE customer');
-        $this->addSql('DROP TABLE image');
-        $this->addSql('DROP TABLE memory');
-        $this->addSql('DROP TABLE product');
-        $this->addSql('DROP TABLE product_color');
-        $this->addSql('DROP TABLE role');
-        $this->addSql('DROP TABLE user');
-        $this->addSql('DROP TABLE user_role');
+    public function down(Schema $schema): void {
+	    // this down() migration is auto-generated, please modify it to your needs
+	    $this->addSql('DROP TABLE IF EXISTS brand');
+	    $this->addSql('DROP TABLE IF EXISTS color');
+	    $this->addSql('DROP TABLE IF EXISTS country');
+	    $this->addSql('DROP TABLE IF EXISTS customer');
+	    $this->addSql('DROP TABLE IF EXISTS image');
+	    $this->addSql('DROP TABLE IF EXISTS memory');
+	    $this->addSql('DROP TABLE IF EXISTS product');
+	    $this->addSql('DROP TABLE IF EXISTS product_color');
+	    $this->addSql('DROP TABLE IF EXISTS role');
+	    $this->addSql('DROP TABLE IF EXISTS user');
+	    $this->addSql('DROP TABLE IF EXISTS user_role');
     }
 }


### PR DESCRIPTION
Vérifie si tu peux supprimer la migration `Version20220525080537`. Apparemment c'est elle qui duplique les choses.
Sinon tu peux merger cette branche si tu teste et que tout est correct.

Pour la correction que j'ai faite, j'ai rajouté 

- `IF NOT EXISTS` devant `CREATE TABLE`
- `IF EXISTS` devant `DROP TABLE`